### PR TITLE
De Virgo super cluster is deel van de Laniakea super cluster.

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
             De Virgo super cluster bevat 100 tot 200 clusters (groepen van sterrenstelsels) en de lokale groep
             is onderdeel van de Virgo super cluster. De Virgo super cluster heeft een diameter van 110 miljoen
             lichtjaar.
+            De Laniakea "Open Immense Hemel" super cluster bestaat uit vier aparte super clusters waaronder
+            de Virgo super cluster. De Laniakea super cluster heeft een diameter van 520 miljoen lichtjaar.
+            Ongeveer 100.000 tot 150.000 sterrenstelsels maken deel uit van Laniakea.
         </p>
     </body>
 </html>


### PR DESCRIPTION
De Laniakea "Open Immense Hemel" super cluster bestaat uit vier aparte super clusters waaronder de Virgo super cluster. De laniakea super cluster heeft een diameter van 520 miljoen lichtjaar. Ongeveer 100.000 tot 150.000 sterrenstelsels maken deel uit van Laniakea.