### PR TITLE
De Laniakea super cluster maakt deel uit van het waarneembare universum.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@
             De Laniakea "Open Immense Hemel" super cluster bestaat uit vier aparte super clusters waaronder
             de Virgo super cluster. De Laniakea super cluster heeft een diameter van 520 miljoen lichtjaar.
             Ongeveer 100.000 tot 150.000 sterrenstelsels maken deel uit van Laniakea.
+            Het waarneembaar universum is het deel van het heelal dat vanaf de aarde waarneembaar is (en dat ook
+            de Laniakea super cluster omvat). Sterrenstelsel JADES-GS-z13-0 is één van de verst waargenomen
+            objecten en in 2022 door de James Webb ruimtetelescoop ontdekt. JADES-GS-z13-0 heeft een geschatte
+            ouderdom van 13,8 miljard lichtjaar en het is met het uitdijen van het universum ca. 33,6 miljard
+            lichtjaar van ons verwijderd. 
         </p>
     </body>
 </html>


### PR DESCRIPTION
Het waarneembaar universum is het deel van het heelal dat vanaf de aarde waarneembaar is (en dat ook de Laniakea super cluster omvat). Sterrenstelsel JADES-GS-z13-0 is één van de verst waargenomen objecten en in 2022 door de James Webb ruimtetelescoop ontdekt. JADES-GS-z13-0 heeft een geschatte ouderdom van 13,8 miljard lichtjaar en het is met het uitdijen van het universum ca. 33,6 miljard lichtjaar van ons verwijderd.